### PR TITLE
Fix: add proper Docker API filter support via map[string][]string

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -29,7 +29,7 @@ type Options struct {
 	Input            *string
 	All              bool
 	WithSize         bool
-	Filter           *map[string]string
+	Filter *map[string][]string
 	Limit            int
 	DefaultFormat    bool
 	Format           []string // if more than 1 value, we use the later values as fallback for too-small terminal

--- a/cli/parser.go
+++ b/cli/parser.go
@@ -171,11 +171,12 @@ func parseCommandlineInternal(columnKeys []string) (Options, error) {
 						return Options{}, pserr.DirectOutput.New("Failed to parse config file '" + confPath + "': Filter value must have a key and a value (a=b): " + elem)
 					}
 					if opt.Filter == nil {
-						_v := make(map[string]string)
+						_v := make(map[string][]string) 
 						opt.Filter = &_v
 					}
 					filter := *opt.Filter
-					filter[spl[0]] = spl[1]
+					filter[spl[0]] = []string{spl[1]}
+
 					opt.Filter = &filter
 				}
 			} else if tk == "format" {
@@ -340,11 +341,11 @@ func parseCommandlineInternal(columnKeys []string) (Options, error) {
 				return Options{}, pserr.DirectOutput.New("Filter argument must have a key and a value (a=b): " + arg.Key)
 			}
 			if opt.Filter == nil {
-				_v := make(map[string]string)
+				_v := make(map[string][]string) 
 				opt.Filter = &_v
 			}
 			filter := *opt.Filter
-			filter[spl[0]] = spl[1]
+			filter[spl[0]] = []string{spl[1]}
 			opt.Filter = &filter
 			continue
 		}

--- a/docker/api.go
+++ b/docker/api.go
@@ -57,7 +57,7 @@ func ListContainer(ctx *cli.PSContext) ([]byte, error) {
 			return nil, errorx.InternalError.Wrap(err, "Failed to marshal filter")
 		}
 
-		uri += "&filter=" + url.PathEscape(string(bin))
+		uri += "&filters=" + url.PathEscape(string(bin))
 	}
 
 	response, err := client.Get(uri)


### PR DESCRIPTION
This PR fixes `--filter` behavior in `dops` to be compatible with Docker's Remote API.

- Changes internal filter type to `map[string][]string` as required by the Docker API
- Wraps CLI and config values as string slices
- Marshals filters to JSON correctly in `api.go`
- Prevents "Failed to decode Docker API response" error

Tested with:
./dops --filter ancestor=mongo --format="table {{.Names}}\\t{{.Image}}"
```
NAME          IMAGE
----------    --------------------------
mongo_1     localhost/mongo:latest
mongo_2     localhost/mongo:latest
mongo_3     localhost/mongo:latest
mongo_4     localhost/mongo:latest
mongo_5     localhost/mongo:latest
mongo_6     localhost/mongo:latest
mongo_7     localhost/mongo:latest
mongo_8     localhost/mongo:latest

```