### PR TITLE
Removed $-sign in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ More Changes from default docker-ps:
  - Download the latest binary from the [releases page](https://github.com/Mikescher/better-docker-ps/releases) and put it into your PATH (eg /usr/local/bin)
  - You can also use the following one-liner (afterwards you can use the `dops` command everywhere):
 ```
-$> sudo wget "https://github.com/Mikescher/better-docker-ps/releases/latest/download/dops_linux-amd64-static" -O "/usr/local/bin/dops" && sudo chmod +x "/usr/local/bin/dops"
+sudo wget "https://github.com/Mikescher/better-docker-ps/releases/latest/download/dops_linux-amd64-static" -O "/usr/local/bin/dops" && sudo chmod +x "/usr/local/bin/dops"
 ```
 
 ### ArchLinux


### PR DESCRIPTION
It is quite annoying that that $ is prepended to the command as it makes the command not instantly copy-pastable. I removed the symbols and now the line allows for easy copy paste and execute.

Please accept my change to make installing this package easier.