### PR TITLE
Update API version to v1.44

### DIFF
--- a/consts/api.go
+++ b/consts/api.go
@@ -1,4 +1,4 @@
 package consts
 
 // DockerAPIContainerList -> see https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerList
-const DockerAPIContainerList = "http://localhost/v1.24/containers/json"
+const DockerAPIContainerList = "http://localhost/v1.44/containers/json"


### PR DESCRIPTION
To be compatible with Docker Engine v29 for now:
https://docs.docker.com/engine/release-notes/29/#breaking-changes

Closes: #23