### PR TITLE
Add --search / -g option for substring match across all columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The following keys are supported:
  - all
  - size
  - filter (= string array)
+ - search
  - format (= string array)
  - last
  - latest
@@ -210,6 +211,7 @@ Options (default):
   --version                          Show version.
   --all , -a                         Show all containers (default shows just running)
   --filter <ftr>, -f <ftr>           Filter output based on conditions provided
+  --search <str>, -g <str>           Filter output by substring match across all visible columns (case-insensitive)
   --format <fmt>                     Pretty-print containers using a Go template
   --last , -n                        Show n last created containers (includes all states)
   --latest , -l                      Show the latest created container (includes all states)

--- a/cli/options.go
+++ b/cli/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	All              bool
 	WithSize         bool
 	Filter           *map[string][]string
+	Search           *string
 	Limit            int
 	DefaultFormat    bool
 	Format           []string // if more than 1 value, we use the later values as fallback for too-small terminal

--- a/cli/parser.go
+++ b/cli/parser.go
@@ -179,6 +179,8 @@ func parseCommandlineInternal(columnKeys []string) (Options, error) {
 
 					opt.Filter = &filter
 				}
+			} else if tk == "search" {
+				opt.Search = langext.Ptr(tv)
 			} else if tk == "format" {
 				for _, elem := range tvarr {
 					if opt.DefaultFormat {
@@ -351,6 +353,11 @@ func parseCommandlineInternal(columnKeys []string) (Options, error) {
 			}
 			filter[spl[0]] = []string{spl[1]}
 			opt.Filter = &filter
+			continue
+		}
+
+		if (arg.Key == "search" || arg.Key == "g") && arg.Value != nil {
+			opt.Search = langext.Ptr(*arg.Value)
 			continue
 		}
 

--- a/cmd/dops/main.go
+++ b/cmd/dops/main.go
@@ -88,6 +88,7 @@ func printHelp(ctx *cli.PSContext) {
 	ctx.PrintPrimaryOutput("  --version                          Show version.")
 	ctx.PrintPrimaryOutput("  --all , -a                         Show all containers (default shows just running)")
 	ctx.PrintPrimaryOutput("  --filter <ftr>, -f <ftr>           Filter output based on conditions provided")
+	ctx.PrintPrimaryOutput("  --search <str>, -g <str>           Filter output by substring match across all visible columns (case-insensitive)")
 	ctx.PrintPrimaryOutput("  --format <fmt>                     Pretty-print containers using a Go template")
 	ctx.PrintPrimaryOutput("  --last , -n                        Show n last created containers (includes all states)")
 	ctx.PrintPrimaryOutput("  --latest , -l                      Show the latest created container (includes all states)")

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -67,6 +67,10 @@ func executeSingle(ctx *cli.PSContext, clear bool) error {
 		data = doSort(ctx, data, ctx.Opt.SortColumns, ctx.Opt.SortDirection)
 	}
 
+	if ctx.Opt.Search != nil {
+		data = doSearch(ctx, data, *ctx.Opt.Search)
+	}
+
 	for i, v := range ctx.Opt.Format {
 
 		if clear {
@@ -84,6 +88,34 @@ func executeSingle(ctx *cli.PSContext, clear bool) error {
 	}
 
 	return pserr.DirectOutput.New("Missing format specification for output")
+}
+
+func doSearch(ctx *cli.PSContext, data []docker.ContainerSchema, needle string) []docker.ContainerSchema {
+	needle = strings.ToLower(needle)
+
+	haystackFormat := ""
+	for _, f := range ctx.Opt.Format {
+		if strings.HasPrefix(f, "table ") {
+			haystackFormat = f
+			break
+		}
+	}
+
+	result := make([]docker.ContainerSchema, 0, len(data))
+	for _, cont := range data {
+		hay := cont.ID + " " + strings.Join(cont.Names, " ") + " " + cont.Image + " " + cont.Command
+		if haystackFormat != "" {
+			for _, fn := range parseTableDef(haystackFormat) {
+				hay += " " + strings.Join(fn(ctx, data, &cont), " ")
+			}
+		} else if len(ctx.Opt.Format) > 0 {
+			hay += " " + replaceSingleLineColumnData(ctx, data, cont, ctx.Opt.Format[0])
+		}
+		if strings.Contains(strings.ToLower(hay), needle) {
+			result = append(result, cont)
+		}
+	}
+	return result
 }
 
 func doSort(ctx *cli.PSContext, data []docker.ContainerSchema, skeys []string, sdirs []cli.SortDirection) []docker.ContainerSchema {


### PR DESCRIPTION
Piping dops output to grep breaks the responsive terminal-width rendering and strips colors. The new --search flag does client-side case-insensitive substring matching against the raw container fields (ID, names, image, command) plus all cells of the widest configured table format, so matches include visible data like ports and IPs while the adaptive layout stays intact.